### PR TITLE
Pruebasfix(proxy): habilitar TrustProxies para HTTPS detrás de ingres

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,12 +18,5 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
-    {
-        //
-        // Esto detecta si el Ingress del proxy reverse envió la señal de HTTPS  para poder armar el contenedor sin SSL
-        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-            URL::forceScheme('https');
-        }
-    }
+    public function boot(): void {}
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,13 +6,13 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        api: __DIR__.'/../routes/api.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: __DIR__ . '/../routes/web.php',
+        api: __DIR__ . '/../routes/api.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->trustProxies(at: '*');
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
Se configura trustProxies('*') en bootstrap/app.php para que Laravel respete X-Forwarded-* (especialmente X-Forwarded-Proto).

Se elimina el forzado manual de esquema https en AppServiceProvider para evitar lógica duplicada/innecesaria.

Se normalizan las rutas de carga de routes/web.php, routes/api.php y routes/console.php.